### PR TITLE
Add custom listening socket (#69)

### DIFF
--- a/src/EduFramework/Commands/StartCommand.php
+++ b/src/EduFramework/Commands/StartCommand.php
@@ -17,6 +17,7 @@ use Studoo\EduFramework\Core\ConfigCore;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -34,11 +35,27 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class StartCommand extends CommandManage
 {
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption(
+            'port',
+            'p',
+            InputOption::VALUE_OPTIONAL,
+            "Port d\'écoute du serveur de développement",
+            8042
+        );
+    }
+
     /**
      * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // Récupération du port en option
+        $port = $input->getOption('port');
+
         self::$stdOutput->writeln([
             CommandBanner::getBanner(),
             'Check des prérequis d\'' . ConfigCore::getConfig('name'),
@@ -61,7 +78,8 @@ class StartCommand extends CommandManage
             'Pour arrêter le serveur de développement, appuyer sur CTRL+X CTRL+C'
         );
 
-        exec("composer edu:start");
+        exec("Composer\\Config::disableProcessTimeout",);
+        exec("php -S localhost:$port -t public");
 
         return Command::SUCCESS;
     }

--- a/src/EduFramework/Commands/StartCommand.php
+++ b/src/EduFramework/Commands/StartCommand.php
@@ -89,7 +89,7 @@ class StartCommand extends CommandManage
             'Pour arrêter le serveur de développement, appuyer sur CTRL+X CTRL+C'
         );
 
-        exec("Composer\\Config::disableProcessTimeout",);
+//        exec("Composer\\Config::disableProcessTimeout",);
         exec("php -S localhost:$port -t public");
 
         return Command::SUCCESS;

--- a/src/EduFramework/Commands/StartCommand.php
+++ b/src/EduFramework/Commands/StartCommand.php
@@ -89,7 +89,7 @@ class StartCommand extends CommandManage
             'Pour arrêter le serveur de développement, appuyer sur CTRL+X CTRL+C'
         );
 
-//        exec("Composer\\Config::disableProcessTimeout",);
+        exec("Composer\\Config::disableProcessTimeout",);
         exec("php -S localhost:$port -t public");
 
         return Command::SUCCESS;

--- a/src/EduFramework/Commands/StartCommand.php
+++ b/src/EduFramework/Commands/StartCommand.php
@@ -35,6 +35,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class StartCommand extends CommandManage
 {
+    /**
+     * Configure la commande en ajoutant les options nécessaires.
+     *
+     * Cette méthode est appelée pour configurer la commande avant son exécution.
+     * Elle permet d'ajouter des options à la commande, comme le port d'écoute
+     * du serveur de développement. L'option 'port' peut être spécifiée en
+     * utilisant `-p` ou `--port` dans la ligne de commande. Si aucune valeur
+     * n'est fournie, la valeur par défaut de 8042 sera utilisée.
+     *
+     * @return void
+     */
     protected function configure(): void
     {
         parent::configure();

--- a/tests/Command/StartCommandTest.php
+++ b/tests/Command/StartCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Command;
+
+use PHPUnit\Framework\TestCase;
+use Studoo\EduFramework\Commands\DefaultCommand;
+use Studoo\EduFramework\Commands\Extends\AppCommand;
+use Studoo\EduFramework\Commands\StartCommand;
+use Studoo\EduFramework\Core\ConfigCore;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class StartCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        (new ConfigCore([]));
+        $application = new Application(ConfigCore::getConfig('name'), ConfigCore::getConfig('version'));
+        $command = new StartCommand();
+        $application->add($command);
+        $this->commandeTester = new CommandTester($application->get("start"));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->commandeTester = null;
+    }
+    public function testCommandWithCustomPort(): void
+    {
+        $this->commandeTester->execute(['--port' => 9000]);
+        $output = $this->commandeTester->getDisplay();
+        $this->assertStringContainsString('php -S localhost:9000 -t public', $output);
+    }
+}


### PR DESCRIPTION
### Description
Bonsoir cette pull request ajoute la possibilité de spécifier le port d'écoute du serveur de développement via une option dans la commande `start`. 

- **Ajout d'une option `--port` (alias `-p`)** : Permet de spécifier un port pour le serveur de développement. Si aucun port n'est fourni, la valeur par défaut est `8042`.
  
### Changement principal :
- Ajout de la méthode `addOption` dans la commande `StartCommand` pour inclure l'option `port`.

### Comment tester :
1. Exécutez la commande suivante pour démarrer le serveur avec le port par défaut (8042) :
```
php bin/edu start
```

2. Pour spécifier un autre port, utilisez l'option `--port` ou `-p` :
```
php bin/edu start --port 9000
```

#### Deepsource-io conseille :
```
use Symfony\Component\Process\Exception\ProcessFailedException;
use Symfony\Component\Process\Process;

$process = new Process(['ls', '-lsa', $_POST['path']]);
$process->run();

if ($process->isSuccessful()) {
    echo $process->getOutput();
}
```
### Checklist :
- [x] Norme PSR-2 respecté
- [x] Code propre et sans erreur
- [ ] Tests effectués sur les changements (impossible de lancer les test mais test écrit) 
- [x] Javadoc
- [ ] Affichage (jolie) pour la gestion des erreurs
